### PR TITLE
Update base to Bookworm

### DIFF
--- a/.github/workflows/notify-ci.yml
+++ b/.github/workflows/notify-ci.yml
@@ -1,0 +1,31 @@
+name: Notify build repo (pureftpd)
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch
+        env:
+          DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          TARGET_REPO: ${{ vars.DISPATCH_TARGET }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          curl -fsSL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            "https://api.github.com/repos/${TARGET_REPO}/dispatches" \
+            -d "$(jq -nc --arg sha "$SHA" '
+              {
+                event_type: "dep_changed",
+                client_payload: {
+                  dep: "pureftpd",
+                  ref: "master",
+                  sha: $sha
+                }
+              }')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ RUN rm -f /etc/apt/sources.list.d/debian.sources && \
     dpkg -i /tmp/pure-ftpd-common*.deb /tmp/pure-ftpd-mysql*.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/*.deb
 
-# Add entrypoint script and permissions
 COPY --chown=docker:docker run.sh /run.sh
 RUN chmod u+x /run.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM debian:bookworm AS builder
 
-# properly setup debian sources
 ENV DEBIAN_FRONTEND=noninteractive
-RUN rm -f /etc/apt/sources.list.d/debian.sources && \
-echo "deb http://deb.debian.org/debian bookworm main\n\
-deb-src http://deb.debian.org/debian bookworm main\n\
-deb http://deb.debian.org/debian bookworm-updates main\n\
-deb-src http://deb.debian.org/debian bookworm-updates main\n\
-deb http://security.debian.org bookworm-security main\n\
-deb-src http://security.debian.org bookworm-security main\n\
-" > /etc/apt/sources.list
+ENV DEB_BUILD_OPTIONS=noddebs
 
-# install packages
-ENV DEBIAN_FRONTEND=noninteractive
+# Set up sources and install build dependencies
+RUN rm -f /etc/apt/sources.list.d/debian.sources && \
+    cat <<EOF > /etc/apt/sources.list
+deb http://deb.debian.org/debian bookworm main
+deb-src http://deb.debian.org/debian bookworm main
+deb http://deb.debian.org/debian bookworm-updates main
+deb-src http://deb.debian.org/debian bookworm-updates main
+deb http://security.debian.org bookworm-security main
+deb-src http://security.debian.org bookworm-security main
+EOF
 RUN apt-get update && apt-get -y upgrade && \
     apt-get -y --force-yes install dpkg-dev debhelper && \
     apt-get -y build-dep pure-ftpd-mysql
@@ -22,30 +22,7 @@ WORKDIR /tmp/pure-ftpd-mysql
 RUN apt-get source pure-ftpd-mysql && \
     cd pure-ftpd-* && \
     sed -i '/^optflags=/ s/$/ --without-capabilities/g' ./debian/rules && \
-    dpkg-buildpackage -j"$(nproc)" -b -uc && \
-    dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-common*.deb && \
-    apt-get -y install openbsd-inetd \
-    default-mysql-client && \
-    dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-mysql*.deb && \
-    apt-mark hold pure-ftpd pure-ftpd-mysql pure-ftpd-common && \
-    apt-get remove -y dpkg-dev libc-dev-bin libc-devtools libssl-dev libsodium-dev libc6-dev linux-libc-dev \
-    libmariadb-dev libmariadb-dev-compat syslog-ng-mod-python python3 && \
-    apt-get purge -y build-essential gcc g++ make cmake ninja-build pkg-config autoconf automake libtool && \
-    apt -y autoremove 
-
-# add docker user and group
-RUN groupadd -g 999 docker
-RUN useradd -u 111 -g 999 -d /dev/null -s /usr/sbin/nologin docker
-RUN chown -R docker:docker /ftpdata
-
-# cleanup
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/*
-
-# run mysql configuration creator script
-COPY run.sh /run.sh
-RUN chmod u+x /run.sh
+    dpkg-buildpackage -j"$(nproc)" -b -uc
 
 # -------------------------------------------------------------------
 FROM debian:bookworm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM debian:buster as builder
+FROM debian:bookworm as builder
 
 # properly setup debian sources
 ENV DEBIAN_FRONTEND noninteractive
-RUN echo "deb http://http.debian.net/debian buster main\n\
-deb-src http://http.debian.net/debian buster main\n\
-deb http://http.debian.net/debian buster-updates main\n\
-deb-src http://http.debian.net/debian buster-updates main\n\
-deb http://security.debian.org buster/updates main\n\
-deb-src http://security.debian.org buster/updates main\n\
+RUN echo "deb http://deb.debian.org/debian bookworm main\n\
+deb-src http://deb.debian.org/debian bookworm main\n\
+deb http://deb.debian.org/debian bookworm-updates main\n\
+deb-src http://deb.debian.org/debian bookworm-updates main\n\
+deb http://security.debian.org bookworm-security main\n\
+deb-src http://security.debian.org bookworm-security main\n\
 " > /etc/apt/sources.list
 
 # install packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ deb-src http://security.debian.org bookworm-security main\n\
 
 # install packages
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get upgrade && \
+RUN apt-get update && apt-get -y upgrade && \
     apt-get -y --force-yes install openssl dpkg-dev debhelper syslog-ng-core syslog-ng && \
     apt-get -y build-dep pure-ftpd-mysql && \
     mkdir /ftpdata && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ FROM debian:trixie
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy and install only built .deb files, remove installers/deps after
 COPY --from=builder /tmp/pure-ftpd-mysql/pure-ftpd*.deb /tmp/
 
 # Set up sources and runtime dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get -y upgrade && \
     default-mysql-client && \
     dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-mysql*.deb && \
     apt-mark hold pure-ftpd pure-ftpd-mysql pure-ftpd-common && \
-    apt-get remove -y dpkg-dev syslog-ng-mod-python python3 && \
+    apt-get remove -y dpkg-dev libc-dev-bin libc-devtools libssl-dev libsodium-dev libc6-dev linux-libc-dev \
+    libmariadb-dev libmariadb-dev-compat syslog-ng-mod-python python3 && \
     apt-get purge -y build-essential gcc g++ make cmake ninja-build pkg-config autoconf automake libtool && \
     apt -y autoremove 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,60 @@
+FROM debian:bookworm AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEB_BUILD_OPTIONS=noddebs
+
+# Set up sources and install build dependencies
+RUN rm -f /etc/apt/sources.list.d/debian.sources && \
+    cat <<EOF > /etc/apt/sources.list
+deb http://deb.debian.org/debian bookworm main
+deb-src http://deb.debian.org/debian bookworm main
+deb http://deb.debian.org/debian bookworm-updates main
+deb-src http://deb.debian.org/debian bookworm-updates main
+deb http://security.debian.org bookworm-security main
+deb-src http://security.debian.org bookworm-security main
+EOF
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get -y --force-yes install dpkg-dev debhelper && \
+    apt-get -y build-dep pure-ftpd-mysql
+
+WORKDIR /tmp/pure-ftpd-mysql
+
+RUN apt-get source pure-ftpd-mysql && \
+    cd pure-ftpd-* && \
+    sed -i '/^optflags=/ s/$/ --without-capabilities/g' ./debian/rules && \
+    dpkg-buildpackage -j"$(nproc)" -b -uc
+
+# -------------------------------------------------------------------
 FROM debian:bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# configure debian sources and install all dependencies in as few layers as possible
+# Set up sources and runtime dependencies
 RUN rm -f /etc/apt/sources.list.d/debian.sources && \
-    echo "deb http://deb.debian.org/debian bookworm main\ndeb-src http://deb.debian.org/debian bookworm main\ndeb http://deb.debian.org/debian bookworm-updates main\ndeb-src http://deb.debian.org/debian bookworm-updates main\ndeb http://security.debian.org bookworm-security main\ndeb-src http://security.debian.org bookworm-security main" > /etc/apt/sources.list && \
-    apt-get update && apt-get -y upgrade && \
-    apt-get -y --force-yes install openssl dpkg-dev debhelper syslog-ng-core syslog-ng && \
-    apt-get -y build-dep pure-ftpd-mysql && \
-    mkdir /ftpdata /tmp/pure-ftpd-mysql && \
-    cd /tmp/pure-ftpd-mysql && \
-    apt-get source pure-ftpd-mysql && \
-    cd pure-ftpd-* && \
-    sed -i '/^optflags=/ s/$/ --without-capabilities/g' ./debian/rules && \
-    dpkg-buildpackage -j"$(nproc)" -b -uc && \
-    dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-common*.deb && \
-    apt-get -y install openbsd-inetd default-mysql-client && \
-    dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-mysql*.deb && \
-    apt-mark hold pure-ftpd pure-ftpd-mysql pure-ftpd-common && \
-    apt-get remove -y dpkg-dev libc-dev-bin libc-devtools libssl-dev libsodium-dev libc6-dev linux-libc-dev \
-        libmariadb-dev libmariadb-dev-compat syslog-ng-mod-python python3 && \
-    apt-get purge -y build-essential gcc g++ make cmake ninja-build pkg-config autoconf automake libtool && \
-    apt -y autoremove && \
+    cat <<EOF > /etc/apt/sources.list
+deb http://deb.debian.org/debian bookworm main
+deb http://deb.debian.org/debian bookworm-updates main
+deb http://security.debian.org bookworm-security main
+EOF
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        openssl syslog-ng-core syslog-ng openbsd-inetd default-mysql-client libsodium23 && \
     groupadd -g 999 docker && \
     useradd -u 111 -g 999 -d /dev/null -s /usr/sbin/nologin docker && \
-    chown -R docker:docker /ftpdata && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+    mkdir /ftpdata && \
+    chown -R docker:docker /ftpdata
 
+# Copy and install only built .deb files, remove installers/deps after
+COPY --from=builder /tmp/pure-ftpd-mysql/pure-ftpd-common*.deb /tmp/
+COPY --from=builder /tmp/pure-ftpd-mysql/pure-ftpd-mysql*.deb /tmp/
+
+RUN dpkg -i /tmp/pure-ftpd-common*.deb /tmp/pure-ftpd-mysql*.deb && \
+    rm -rf /var/lib/apt/lists/* /tmp/*.deb
+
+# Add entrypoint script and permissions
 COPY --chown=docker:docker run.sh /run.sh
 RUN chmod u+x /run.sh
 
 VOLUME /ftpdata
 EXPOSE 20 21 30000-30009
-
 ENTRYPOINT ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm AS builder
 
 # properly setup debian sources
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN rm -f /etc/apt/sources.list.d/debian.sources && \
 echo "deb http://deb.debian.org/debian bookworm main\n\
 deb-src http://deb.debian.org/debian bookworm main\n\
@@ -12,7 +12,7 @@ deb-src http://security.debian.org bookworm-security main\n\
 " > /etc/apt/sources.list
 
 # install packages
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y upgrade && \
     apt-get -y --force-yes install openssl dpkg-dev debhelper syslog-ng-core syslog-ng && \
     apt-get -y build-dep pure-ftpd-mysql && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM debian:bookworm as builder
+FROM debian:bookworm AS builder
 
 # properly setup debian sources
 ENV DEBIAN_FRONTEND noninteractive
-RUN echo "deb http://deb.debian.org/debian bookworm main\n\
+RUN rm -f /etc/apt/sources.list.d/debian.sources && \
+echo "deb http://deb.debian.org/debian bookworm main\n\
 deb-src http://deb.debian.org/debian bookworm main\n\
 deb http://deb.debian.org/debian bookworm-updates main\n\
 deb-src http://deb.debian.org/debian bookworm-updates main\n\
@@ -12,7 +13,7 @@ deb-src http://security.debian.org bookworm-security main\n\
 
 # install packages
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update &&  apt-get -y dist-upgrade && \
+RUN apt-get update && apt-get upgrade && \
     apt-get -y --force-yes install openssl dpkg-dev debhelper syslog-ng-core syslog-ng && \
     apt-get -y build-dep pure-ftpd-mysql && \
     mkdir /ftpdata && \
@@ -26,7 +27,10 @@ RUN apt-get update &&  apt-get -y dist-upgrade && \
     apt-get -y install openbsd-inetd \
     default-mysql-client && \
     dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-mysql*.deb && \
-    apt-mark hold pure-ftpd pure-ftpd-mysql pure-ftpd-common
+    apt-mark hold pure-ftpd pure-ftpd-mysql pure-ftpd-common && \
+    apt-get remove -y dpkg-dev && \
+    apt-get purge -y build-essential gcc g++ make cmake ninja-build pkg-config autoconf automake libtool && \
+    apt -y autoremove 
 
 # add docker user and group
 RUN groupadd -g 999 docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,36 @@
-FROM debian:bookworm AS builder
+FROM debian:bookworm
 
-# properly setup debian sources
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# configure debian sources and install all dependencies in as few layers as possible
 RUN rm -f /etc/apt/sources.list.d/debian.sources && \
-echo "deb http://deb.debian.org/debian bookworm main\n\
-deb-src http://deb.debian.org/debian bookworm main\n\
-deb http://deb.debian.org/debian bookworm-updates main\n\
-deb-src http://deb.debian.org/debian bookworm-updates main\n\
-deb http://security.debian.org bookworm-security main\n\
-deb-src http://security.debian.org bookworm-security main\n\
-" > /etc/apt/sources.list
-
-# install packages
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get -y upgrade && \
+    echo "deb http://deb.debian.org/debian bookworm main\ndeb-src http://deb.debian.org/debian bookworm main\ndeb http://deb.debian.org/debian bookworm-updates main\ndeb-src http://deb.debian.org/debian bookworm-updates main\ndeb http://security.debian.org bookworm-security main\ndeb-src http://security.debian.org bookworm-security main" > /etc/apt/sources.list && \
+    apt-get update && apt-get -y upgrade && \
     apt-get -y --force-yes install openssl dpkg-dev debhelper syslog-ng-core syslog-ng && \
     apt-get -y build-dep pure-ftpd-mysql && \
-    mkdir /ftpdata && \
-    mkdir /tmp/pure-ftpd-mysql && \
+    mkdir /ftpdata /tmp/pure-ftpd-mysql && \
     cd /tmp/pure-ftpd-mysql && \
     apt-get source pure-ftpd-mysql && \
     cd pure-ftpd-* && \
     sed -i '/^optflags=/ s/$/ --without-capabilities/g' ./debian/rules && \
-    dpkg-buildpackage -b -uc && \
+    dpkg-buildpackage -j"$(nproc)" -b -uc && \
     dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-common*.deb && \
-    apt-get -y install openbsd-inetd \
-    default-mysql-client && \
+    apt-get -y install openbsd-inetd default-mysql-client && \
     dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-mysql*.deb && \
     apt-mark hold pure-ftpd pure-ftpd-mysql pure-ftpd-common && \
     apt-get remove -y dpkg-dev libc-dev-bin libc-devtools libssl-dev libsodium-dev libc6-dev linux-libc-dev \
-    libmariadb-dev libmariadb-dev-compat syslog-ng-mod-python python3 && \
+        libmariadb-dev libmariadb-dev-compat syslog-ng-mod-python python3 && \
     apt-get purge -y build-essential gcc g++ make cmake ninja-build pkg-config autoconf automake libtool && \
-    apt -y autoremove 
+    apt -y autoremove && \
+    groupadd -g 999 docker && \
+    useradd -u 111 -g 999 -d /dev/null -s /usr/sbin/nologin docker && \
+    chown -R docker:docker /ftpdata && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
-# add docker user and group
-RUN groupadd -g 999 docker
-RUN useradd -u 111 -g 999 -d /dev/null -s /usr/sbin/nologin docker
-RUN chown -R docker:docker /ftpdata
-
-# cleanup
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/*
-
-# run mysql configuration creator script
-COPY run.sh /run.sh
+COPY --chown=docker:docker run.sh /run.sh
 RUN chmod u+x /run.sh
 
-# entry point
-ENTRYPOINT ["/run.sh"]
-
-# define important volumes
 VOLUME /ftpdata
-
-# expose important ports
 EXPOSE 20 21 30000-30009
+
+ENTRYPOINT ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm AS builder
+FROM debian:trixie-slim AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEB_BUILD_OPTIONS=noddebs
@@ -6,12 +6,12 @@ ENV DEB_BUILD_OPTIONS=noddebs
 # Set up sources and install build dependencies
 RUN rm -f /etc/apt/sources.list.d/debian.sources && \
     cat <<EOF > /etc/apt/sources.list
-deb http://deb.debian.org/debian bookworm main
-deb-src http://deb.debian.org/debian bookworm main
-deb http://deb.debian.org/debian bookworm-updates main
-deb-src http://deb.debian.org/debian bookworm-updates main
-deb http://security.debian.org bookworm-security main
-deb-src http://security.debian.org bookworm-security main
+deb http://deb.debian.org/debian trixie main
+deb-src http://deb.debian.org/debian trixie main
+deb http://deb.debian.org/debian trixie-updates main
+deb-src http://deb.debian.org/debian trixie-updates main
+deb http://security.debian.org trixie-security main
+deb-src http://security.debian.org trixie-security main
 EOF
 RUN apt-get update && apt-get -y upgrade && \
     apt-get -y --force-yes install dpkg-dev debhelper && \
@@ -29,7 +29,7 @@ RUN apt-get source pure-ftpd-mysql && \
     dpkg-buildpackage -j"$(nproc)" -b -uc
 
 # -------------------------------------------------------------------
-FROM debian:bookworm
+FROM debian:trixie
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -38,7 +38,7 @@ COPY --from=builder /tmp/pure-ftpd-mysql/pure-ftpd*.deb /tmp/
 
 # Set up sources and runtime dependencies
 RUN rm -f /etc/apt/sources.list.d/debian.sources && \
-    echo "deb http://deb.debian.org/debian bookworm main\ndeb-src http://deb.debian.org/debian bookworm main\ndeb http://deb.debian.org/debian bookworm-updates main\ndeb-src http://deb.debian.org/debian bookworm-updates main\ndeb http://security.debian.org bookworm-security main\ndeb-src http://security.debian.org bookworm-security main" > /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian trixie main\ndeb-src http://deb.debian.org/debian trixie main\ndeb http://deb.debian.org/debian trixie-updates main\ndeb-src http://deb.debian.org/debian trixie-updates main\ndeb http://security.debian.org trixie-security main\ndeb-src http://security.debian.org trixie-security main" > /etc/apt/sources.list && \
     apt-get update && apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
         openssl syslog-ng-core syslog-ng openbsd-inetd default-mysql-client libsodium23 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get source pure-ftpd-mysql && \
     cd pure-ftpd-* && \
     sed -i '/^optflags=/ s/$/ --without-capabilities/g' ./debian/rules && \
-    dpkg-buildpackage -b -uc && \
+    dpkg-buildpackage -j"$(nproc)" -b -uc && \
     dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-common*.deb && \
     apt-get -y install openbsd-inetd \
     default-mysql-client && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,14 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get -y build-dep pure-ftpd-mysql
 
 WORKDIR /tmp/pure-ftpd-mysql
+COPY rules /tmp/pureftpd-rules
 
 RUN apt-get source pure-ftpd-mysql && \
     cd pure-ftpd-* && \
-    sed -i '/^optflags=/ s/$/ --without-capabilities/g' ./debian/rules && \
+    cp /tmp/pureftpd-rules debian/rules && \
+    sed -i '/^Package: pure-ftpd-ldap/,/^$/d' debian/control && \
+    sed -i '/^Package: pure-ftpd-postgresql/,/^$/d' debian/control && \
+    rm -f debian/pure-ftpd-ldap* debian/pure-ftpd-postgresql* && \
     dpkg-buildpackage -j"$(nproc)" -b -uc
 
 # -------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get -y upgrade && \
     default-mysql-client && \
     dpkg -i /tmp/pure-ftpd-mysql/pure-ftpd-mysql*.deb && \
     apt-mark hold pure-ftpd pure-ftpd-mysql pure-ftpd-common && \
-    apt-get remove -y dpkg-dev && \
+    apt-get remove -y dpkg-dev syslog-ng-mod-python python3 && \
     apt-get purge -y build-essential gcc g++ make cmake ninja-build pkg-config autoconf automake libtool && \
     apt -y autoremove 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Pure-ftpd with MySQL, TLS, Quota, Bandwith control and Passive mode
 
+## Fork information
+
+This fork uses Debian Bookworm as base, and PureFTPD 1.0.50.
+This also means that md5 and other older password hash formats are unsupported.
+There is no migration, new password can be generated with `openssl passwd -6` command for example.
+
 ## Usage
 
 * Create a MySQL container and import `pureftp.sql` file to create the database

--- a/pureftp.sql
+++ b/pureftp.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `ftpd` (
   `User` varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `status` enum('0','1') COLLATE utf8_unicode_ci NOT NULL DEFAULT '1',
-  `Password` varchar(64) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  `Password` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
   `Uid` varchar(11) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'ftpuser',
   `Gid` varchar(11) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'ftpgroup',
   `Dir` varchar(250) COLLATE utf8_unicode_ci NOT NULL DEFAULT '/ftpdata',

--- a/rules
+++ b/rules
@@ -1,0 +1,185 @@
+#!/usr/bin/make -f
+# adapted from sample debian/rules that uses debhelper,
+# GNU copyright 1997 to 1999 by Joey Hess.
+# Copyright 2002-2016 by Stefan Hornburg (Racke) <racke@linuxia.de>
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
+
+cfgflags=--sysconfdir=/etc/pure-ftpd CFLAGS="-O2 -DMAX_USER_LENGTH=128U -g"
+optflags=--with-everything --with-largefile --with-pam --with-privsep --with-tls --with-rfc2640 --without-capabilities
+bin=pure-pw pure-statsdecode pure-pwconvert
+sbin=pure-authd pure-certd pure-ftpwho pure-uploadscript pure-quotacheck pure-ftpd pure-mrtginfo
+
+FLAVOURS=pure-ftpd-mysql
+
+src/vanilla/pure-ftpd:
+	dh_testdir
+	[ ! -f Makefile ] || $(MAKE) distclean
+	dh_auto_configure -- $(cfgflags) $(optflags)
+	$(MAKE)
+	mkdir $(@D)
+	mv $(addprefix src/, $(bin) $(sbin)) $(@D)
+
+src/mysql/pure-ftpd:
+	dh_testdir
+	[ ! -f Makefile ] || $(MAKE) distclean
+	dh_auto_configure -- $(cfgflags) $(optflags) --with-mysql
+	$(MAKE)
+	mkdir $(@D)
+	mv $(addprefix src/, $(bin) $(sbin)) $(@D)
+
+src/vanilla-virtualchroot/pure-ftpd:
+	dh_testdir
+	[ ! -f Makefile ] || $(MAKE) distclean
+	dh_auto_configure -- $(cfgflags) $(optflags) --with-virtualchroot
+	$(MAKE)
+	mkdir $(@D)
+	mv $(addprefix src/, $(bin) $(sbin)) $(@D)
+
+src/mysql-virtualchroot/pure-ftpd:
+	dh_testdir
+	[ ! -f Makefile ] || $(MAKE) distclean
+	dh_auto_configure -- $(cfgflags) $(optflags) --with-virtualchroot --with-mysql
+	$(MAKE)
+	mkdir $(@D)
+	mv $(addprefix src/, $(bin) $(sbin)) $(@D)
+
+build: build-arch build-indep
+build-arch: build-stamp
+build-indep: build-stamp
+
+build-stamp: src/vanilla/pure-ftpd src/mysql/pure-ftpd src/vanilla-virtualchroot/pure-ftpd src/mysql-virtualchroot/pure-ftpd
+	dh_testdir
+# create duplicates of the init script with unique provides
+	for suffix in -ldap -mysql -postgresql; do \
+		install -m 0644 -p debian/pure-ftpd.init.d debian/pure-ftpd$$suffix.init.d; \
+		sed -i -e "/Provides:/s/pure-ftpd/pure-ftpd$$suffix/" \
+	       debian/pure-ftpd$$suffix.init.d; \
+	done
+
+	touch build-stamp
+
+clean:
+	dh_testdir
+	dh_testroot
+	[ ! -f Makefile ] || $(MAKE) distclean
+	rm -f build-stamp configure-stamp config.status
+	rm -f debian/pure-ftpd-*.init.d
+	for package in $(FLAVOURS); do \
+		rm -f debian/$$package.post* debian/$$package.pre*; \
+	done
+	rm -rf src/.deps puredb/src/.deps src/vanilla src/ldap src/mysql src/postgresql src/vanilla-virtualchroot src/ldap-virtualchroot src/mysql-virtualchroot src/postgresql-virtualchroot
+	dh_clean
+
+install: build
+	dh_testdir
+	dh_testroot
+	dh_prep
+	dh_installdirs -ppure-ftpd-common etc/pam.d
+	dh_installdirs -A -Npure-ftpd-common usr/bin usr/sbin
+
+# install docs and changelogs
+	dh_installdocs -ppure-ftpd-common --exclude=Windows --exclude=MacOS AUTHORS HISTORY THANKS README* pureftpd.schema
+	dh_installdocs -Npure-ftpd-common --exclude=Windows --exclude=MacOS
+	dh_installchangelogs -p pure-ftpd-common ChangeLog
+
+# pam and init
+	install -p -m644 debian/pam debian/pure-ftpd-common/etc/pam.d/pure-ftpd
+	dh_installinit
+
+# logrotate
+	dh_installlogrotate
+
+# install into debian/pure-ftpd-common
+# include binaries to make "make install" happy
+	cp src/vanilla/* src
+	$(MAKE) install DESTDIR=$(CURDIR)/debian/pure-ftpd-common #prefix=$(CURDIR)/debian/pure-ftpd-common/usr
+# now remove binaries from package
+	rm -r $(CURDIR)/debian/pure-ftpd-common/usr/bin
+	rm $(CURDIR)/debian/pure-ftpd-common/usr/sbin/*
+	install -m 0644 debian/ftpallow $(CURDIR)/debian/pure-ftpd-common/etc/
+	for package in $(FLAVOURS); do \
+		install -m 0644 debian/ftpusers $(CURDIR)/debian/$$package/etc; \
+	done
+	install -m 0755 $(addprefix src/vanilla/, $(bin)) \
+		$(CURDIR)/debian/pure-ftpd/usr/bin
+	install -m 0755 $(addprefix src/vanilla/, $(sbin)) \
+		$(CURDIR)/debian/pure-ftpd/usr/sbin
+	install -m 0755 $(addprefix src/mysql/, $(bin)) \
+		$(CURDIR)/debian/pure-ftpd-mysql/usr/bin
+	install -m 0755 $(addprefix src/mysql/, $(sbin)) \
+		$(CURDIR)/debian/pure-ftpd-mysql/usr/sbin
+	(cd $(CURDIR)/debian/pure-ftpd-mysql/usr/sbin/; mv pure-ftpd pure-ftpd-mysql)
+	install -m 0755 $(CURDIR)/src/vanilla-virtualchroot/pure-ftpd $(CURDIR)/debian/pure-ftpd/usr/sbin/pure-ftpd-virtualchroot
+	install -m 0755 $(CURDIR)/src/mysql-virtualchroot/pure-ftpd $(CURDIR)/debian/pure-ftpd-mysql/usr/sbin/pure-ftpd-mysql-virtualchroot
+
+# install config files
+	install -d $(CURDIR)/debian/pure-ftpd-common/etc/pure-ftpd/conf
+	install -d $(CURDIR)/debian/pure-ftpd-common/etc/pure-ftpd/db
+	install -m 0644 debian/pureftpd-dir-aliases $(CURDIR)/debian/pure-ftpd-common/etc/pure-ftpd
+	for f in debian/etc/*; do if [ -f $$f ]; then install -m 0644 $$f $(CURDIR)/debian/pure-ftpd-common/etc/pure-ftpd/conf; fi; done
+	install -d $(CURDIR)/debian/pure-ftpd-mysql/etc/pure-ftpd/conf
+	install -d $(CURDIR)/debian/pure-ftpd-mysql/etc/pure-ftpd/db
+	install -m 0644 debian/etc/mysql/* $(CURDIR)/debian/pure-ftpd-mysql/etc/pure-ftpd/conf
+# links for authentication configuration
+	install -d $(CURDIR)/debian/pure-ftpd-common/etc/pure-ftpd/auth
+	(cd $(CURDIR)/debian/pure-ftpd-common/etc/pure-ftpd/auth && ln -s ../conf/PAMAuthentication 70pam && ln -s ../conf/UnixAuthentication 65unix)
+	install -d $(CURDIR)/debian/pure-ftpd-mysql/etc/pure-ftpd/auth
+	(cd $(CURDIR)/debian/pure-ftpd-mysql/etc/pure-ftpd/auth && ln -s ../conf/MySQLConfigFile 30mysql)
+# database configuration files
+	install -d $(CURDIR)/debian/pure-ftpd-mysql/etc/pure-ftpd/db
+	perl -pe 's%^MYSQLSocket.*%MYSQLSocket      /var/run/mysqld/mysqld.sock%' pureftpd-mysql.conf > $(CURDIR)/debian/pure-ftpd-mysql/etc/pure-ftpd/db/mysql.conf
+
+# install the wrapper, control script and corresponding manual pages
+	install -m 0755 debian/pure-ftpd-wrapper $(CURDIR)/debian/pure-ftpd-common/usr/sbin
+	pod2man --center='Debian GNU/Linux Documentation' --release='Debian GNU/Linux '`cat /etc/debian_version` --section=8 debian/pure-ftpd-wrapper > $(CURDIR)/debian/pure-ftpd-common/usr/share/man/man8/pure-ftpd-wrapper.8
+	install -m 0755 debian/pure-ftpd-control $(CURDIR)/debian/pure-ftpd-common/usr/sbin
+	pod2man --center='Debian GNU/Linux Documentation' --release='Debian GNU/Linux '`cat /etc/debian_version` --section=8 debian/pure-ftpd-control > $(CURDIR)/debian/pure-ftpd-common/usr/share/man/man8/pure-ftpd-control.8
+# fix path in pure-pw manual pages
+	perl -i -pe 's%/etc/pureftpd\.%/etc/pure-ftpd/pureftpd.%' $(CURDIR)/debian/pure-ftpd-common/usr/share/man/man8/pure-pw.8
+# install log and runtime directory
+	install -m 0700 -d $(CURDIR)/debian/pure-ftpd-common/var/log/pure-ftpd
+# shared maintainer scripts
+	for package in $(FLAVOURS); do\
+		for script in postinst prerm ; do \
+			install -p debian/flavour.$$script debian/$$package.$$script; \
+		done; \
+	done
+
+# Build architecture-independent files here.
+binary-indep: build install
+# We have nothing to do by default.
+	dh_testdir
+	dh_testroot
+	dh_installchangelogs -i
+	dh_installdocs -i
+	dh_installexamples -i
+	dh_installdebconf -i
+	dh_link -i
+	dh_strip -i
+	dh_compress -i
+	dh_fixperms -i
+	dh_installdeb -i
+	dh_shlibdeps -i
+	dh_gencontrol -i
+	dh_md5sums -i
+	dh_builddeb -i
+
+# Build architecture-dependent files here.
+binary-arch: build install
+	dh_testdir
+	dh_testroot
+	dh_installchangelogs -a
+	dh_link -a
+	dh_strip -a
+	dh_compress -a
+	dh_fixperms -a
+	dh_installdeb -a
+	dh_shlibdeps -a
+	dh_gencontrol -a
+	dh_md5sums -a
+	dh_builddeb -a
+
+
+binary: binary-indep binary-arch
+.PHONY: build clean binary-indep binary-arch binary install configure

--- a/run.sh
+++ b/run.sh
@@ -39,6 +39,7 @@ fi
 # start syslog service
 service syslog-ng start
 
+
 # run command
 # -l define login/mysql configuration
 # -J define TLS cypher

--- a/run.sh
+++ b/run.sh
@@ -51,4 +51,5 @@ service syslog-ng start
 # -A chroot everyone
 # -B daemonize
 # -P external ip for passive mode
+mkdir -p /var/log/pure-ftpd && touch /var/log/pure-ftpd/transfer.log
 /usr/sbin/pure-ftpd-mysql -l mysql:/etc/pure-ftpd/db/mysql.conf -E -O clf:/var/log/pure-ftpd/transfer.log -c 100 -C 100 -u 30 -U 111:000 -p 30000:30059 -Y $TLS -H -A -B -P ${EXTERNAL_IP:-localhost} && tail -f /var/log/messages /var/log/pure-ftpd/transfer.log

--- a/run.sh
+++ b/run.sh
@@ -51,4 +51,4 @@ service syslog-ng start
 # -A chroot everyone
 # -B daemonize
 # -P external ip for passive mode
-/usr/sbin/pure-ftpd-mysql -l mysql:/etc/pure-ftpd/db/mysql.conf -E -O clf:/var/log/pure-ftpd/transfer.log -c 100 -C 100 -8 UTF-8 -u 30 -U 111:000 -p 30000:30059 -Y $TLS -H -A -B -P ${EXTERNAL_IP:-localhost} && tail -f /var/log/*.log
+/usr/sbin/pure-ftpd-mysql -l mysql:/etc/pure-ftpd/db/mysql.conf -E -O clf:/var/log/pure-ftpd/transfer.log -c 100 -C 100 -u 30 -U 111:000 -p 30000:30059 -Y $TLS -H -A -B -P ${EXTERNAL_IP:-localhost} && tail -f /var/log/messages

--- a/run.sh
+++ b/run.sh
@@ -39,7 +39,6 @@ fi
 # start syslog service
 service syslog-ng start
 
-
 # run command
 # -l define login/mysql configuration
 # -J define TLS cypher

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # mysql configuration
+# sadly, md5 support was removed in 1.0.50 so this is a breaking change
+# password hash can be generated with openssl -6 "plainpw"
 cat << EOM > /etc/pure-ftpd/db/mysql.conf
 #MYSQLSocket        /var/run/mysqld/mysqld.sock
 MYSQLServer         ${MYSQL_HOST:-mysql}
@@ -8,7 +10,7 @@ MYSQLPort           ${MYSQL_PORT:-3306}
 MYSQLUser           ${MYSQL_USER:-pureftpd}
 MYSQLPassword       ${MYSQL_PASSWORD:-password}
 MYSQLDatabase       ${MYSQL_DATABASE:-pureftpd}
-MYSQLCrypt          md5
+MYSQLCrypt          crypt
 MYSQLGetPW          SELECT Password FROM ftpd WHERE User="\L" AND status="1" AND (ipaccess = "*" OR ipaccess LIKE "\R")
 MYSQLGetUID         SELECT Uid FROM ftpd WHERE User="\L" AND status="1" AND (ipaccess = "*" OR ipaccess LIKE "\R")
 MYSQLGetGID         SELECT Gid FROM ftpd WHERE User="\L"AND status="1" AND (ipaccess = "*" OR ipaccess LIKE "\R")

--- a/run.sh
+++ b/run.sh
@@ -51,4 +51,4 @@ service syslog-ng start
 # -A chroot everyone
 # -B daemonize
 # -P external ip for passive mode
-/usr/sbin/pure-ftpd-mysql -l mysql:/etc/pure-ftpd/db/mysql.conf -E -O clf:/var/log/pure-ftpd/transfer.log -c 100 -C 100 -u 30 -U 111:000 -p 30000:30059 -Y $TLS -H -A -B -P ${EXTERNAL_IP:-localhost} && tail -f /var/log/messages
+/usr/sbin/pure-ftpd-mysql -l mysql:/etc/pure-ftpd/db/mysql.conf -E -O clf:/var/log/pure-ftpd/transfer.log -c 100 -C 100 -u 30 -U 111:000 -p 30000:30059 -Y $TLS -H -A -B -P ${EXTERNAL_IP:-localhost} && tail -f /var/log/messages /var/log/pure-ftpd/transfer.log


### PR DESCRIPTION
I am unsure on the usefulness of this to others, but for what it's worth I'm opening PR. The original project is not buildable anymore since buster repos are already in archive. 

This bumps PureFTPD to 1.0.50 which also means that legacy password formats won't work - these were removed from PureFTPD a good [6 years ago](https://github.com/jedisct1/pure-ftpd/commit/ed78ab681e7025c3f6eee0106d504095995fee90)

Some more logging is also added to the container console.